### PR TITLE
save agentic_traces and zip_code to tmp dir

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/base.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/base.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 import uuid
 import sys
+import tempfile
 
 from .data_structure import (
     Trace, Metadata, SystemInfo, OSInfo, EnvironmentInfo,
@@ -182,14 +183,13 @@ class BaseTracer:
             self.trace = self._extract_cost_tokens(self.trace)
             
             # Create traces directory if it doesn't exist
-            self.traces_dir = Path("traces")
-            self.traces_dir.mkdir(exist_ok=True)
+            self.traces_dir = tempfile.gettempdir()
             filename = self.trace.id + ".json"
-            filepath = self.traces_dir / filename
+            filepath = f"{self.traces_dir}/{filename}"
 
             #get unique files and zip it. Generate a unique hash ID for the contents of the files
             list_of_unique_files = self.file_tracker.get_unique_files()
-            hash_id, zip_path = zip_list_of_unique_files(list_of_unique_files)
+            hash_id, zip_path = zip_list_of_unique_files(list_of_unique_files, output_dir=self.traces_dir)
 
             #replace source code with zip_path
             self.trace.metadata.system_info.source_code = hash_id

--- a/ragaai_catalyst/tracers/agentic_tracing/zip_list_of_unique_files.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/zip_list_of_unique_files.py
@@ -7,6 +7,8 @@ import importlib.util
 import json
 import astor
 from pathlib import Path
+import logging
+logger = logging.getLogger(__name__)
 
 # Define the PackageUsageRemover class
 class PackageUsageRemover(ast.NodeTransformer):
@@ -165,15 +167,15 @@ class TraceDependencyTracker:
                 try:
                     relative_path = os.path.relpath(filepath, base_path)
                     zipf.write(filepath, relative_path)
-                    print(f"Added to zip: {relative_path}")
+                    # logger.info(f"Added to zip: {relative_path}")
                 except Exception as e:
                     print(f"Warning: Could not add {filepath} to zip: {str(e)}")
 
         return hash_id, zip_filename
 
 # Main function for creating a zip of unique files
-def zip_list_of_unique_files(filepaths):
-    tracker = TraceDependencyTracker()
+def zip_list_of_unique_files(filepaths, output_dir):
+    tracker = TraceDependencyTracker(output_dir)
     return tracker.create_zip(filepaths)
 
 # Example usage


### PR DESCRIPTION
- save agentic_traces and zip_code to tmp dir
- removed unnecessary print statements from zip file